### PR TITLE
feat: add benchmarking of landscape example via cargo bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +101,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +120,58 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "ciborium"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+dependencies = [
+ "ciborium-io",
+ "half 1.8.2",
+]
+
+[[package]]
+name = "clap"
+version = "4.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b417ae4361bca3f5de378294fc7472d3c4ed86a5ef9f49e93ae722f432aae8d2"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c90dc0f0e42c64bff177ca9d7be6fcc9ddb0f26a6e062174a61c84dd6c644d4"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "color_quant"
@@ -127,6 +197,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
 ]
 
 [[package]]
@@ -226,7 +332,7 @@ checksum = "d1e481eb11a482815d3e9d618db8c42a93207134662873809335a92327440c18"
 dependencies = [
  "bit_field",
  "flume",
- "half",
+ "half 2.2.1",
  "lebe",
  "miniz_oxide",
  "rayon-core",
@@ -315,6 +421,12 @@ dependencies = [
 
 [[package]]
 name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "half"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
@@ -390,6 +502,15 @@ dependencies = [
  "hermit-abi 0.3.2",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -537,6 +658,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "ordered-float"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +696,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -713,6 +868,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,6 +985,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,6 +1007,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -902,6 +1086,7 @@ dependencies = [
  "base64",
  "bitvec",
  "colored",
+ "criterion",
  "fastrand",
  "image",
  "indexmap",
@@ -913,6 +1098,16 @@ dependencies = [
  "serde_json",
  "tempfile",
  "uuid",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tempfile = { version = "3.3.0" }
 colored = { version = "2.0.0" }
 image = { version = "0.24.7" }
 base64 = { version = "0.13.1" }
-
+# deps below are used for benchmarks only
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,9 @@ tempfile = { version = "3.3.0" }
 colored = { version = "2.0.0" }
 image = { version = "0.24.7" }
 base64 = { version = "0.13.1" }
+
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "landscape"
+harness = false

--- a/benches/landscape.rs
+++ b/benches/landscape.rs
@@ -276,10 +276,12 @@ fn run() {
 
     wave_function.validate().unwrap();
 
-    let mut random_instance = fastrand::Rng::new();
-    let random_seed = Some(random_instance.u64(..));
-    //let random_seed = Some(0);
+    //let mut random_instance = fastrand::Rng::new();
+    //let random_seed = Some(random_instance.u64(..));
     //let random_seed = None;
+
+    // using a fixed seed for randomness to increase comparaibility of the results
+    let random_seed = Some(0);
 
     let collapsed_wave_function = wave_function
         .get_collapsable_wave_function::<AccommodatingCollapsableWaveFunction<LandscapeElement>>(

--- a/benches/landscape.rs
+++ b/benches/landscape.rs
@@ -1,0 +1,313 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use log::debug;
+use std::{collections::HashMap, slice::Iter};
+extern crate pretty_env_logger;
+use serde::{Deserialize, Serialize};
+use wave_function_collapse::wave_function::{
+    collapsable_wave_function::{
+        accommodating_collapsable_wave_function::AccommodatingCollapsableWaveFunction,
+        collapsable_wave_function::CollapsableWaveFunction,
+    },
+    Node, NodeStateCollection, WaveFunction,
+};
+
+/// This enum represents the possible states of a node in the 2D world
+#[derive(Debug, Eq, Hash, PartialEq, Clone, PartialOrd, Ord, Serialize, Deserialize)]
+enum LandscapeElement {
+    Water,
+    Sand,
+    Grass,
+    Tree,
+    Forest,
+    Hill,
+    Mountain,
+}
+
+impl LandscapeElement {
+    #[allow(dead_code)]
+    fn iter() -> Iter<'static, LandscapeElement> {
+        [
+            LandscapeElement::Water,
+            LandscapeElement::Sand,
+            LandscapeElement::Grass,
+            LandscapeElement::Tree,
+            LandscapeElement::Forest,
+            LandscapeElement::Hill,
+            LandscapeElement::Mountain,
+        ]
+        .iter()
+    }
+    #[allow(dead_code)]
+    fn into_iter() -> std::array::IntoIter<LandscapeElement, 7> {
+        [
+            LandscapeElement::Water,
+            LandscapeElement::Sand,
+            LandscapeElement::Grass,
+            LandscapeElement::Tree,
+            LandscapeElement::Forest,
+            LandscapeElement::Hill,
+            LandscapeElement::Mountain,
+        ]
+        .into_iter()
+    }
+    #[allow(dead_code)]
+    fn get_node_state_ids() -> Vec<String> {
+        let mut node_state_ids: Vec<String> = Vec::new();
+        for landscape_element in LandscapeElement::iter() {
+            node_state_ids.push(landscape_element.to_string());
+        }
+        node_state_ids
+    }
+}
+
+impl std::fmt::Display for LandscapeElement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// This struct represents a 2D landscape of possible elements.
+struct Landscape {
+    width: u32,
+    height: u32,
+}
+
+impl Landscape {
+    fn new(width: u32, height: u32) -> Self {
+        Landscape { width, height }
+    }
+    fn get_wave_function(&self) -> WaveFunction<LandscapeElement> {
+        let mut node_state_collections: Vec<NodeStateCollection<LandscapeElement>> = Vec::new();
+        // water
+        node_state_collections.push(NodeStateCollection::new(
+            String::from("water"),
+            LandscapeElement::Water,
+            vec![LandscapeElement::Water, LandscapeElement::Sand],
+        ));
+        // sand
+        node_state_collections.push(NodeStateCollection::new(
+            String::from("sand"),
+            LandscapeElement::Sand,
+            vec![
+                LandscapeElement::Water,
+                LandscapeElement::Sand,
+                LandscapeElement::Grass,
+            ],
+        ));
+        // grass
+        node_state_collections.push(NodeStateCollection::new(
+            String::from("grass"),
+            LandscapeElement::Grass,
+            vec![
+                LandscapeElement::Sand,
+                LandscapeElement::Grass,
+                LandscapeElement::Tree,
+                LandscapeElement::Hill,
+            ],
+        ));
+        // tree
+        node_state_collections.push(NodeStateCollection::new(
+            String::from("tree"),
+            LandscapeElement::Tree,
+            vec![
+                LandscapeElement::Grass,
+                LandscapeElement::Tree,
+                LandscapeElement::Forest,
+            ],
+        ));
+        // forest
+        node_state_collections.push(NodeStateCollection::new(
+            String::from("forest"),
+            LandscapeElement::Forest,
+            vec![LandscapeElement::Tree, LandscapeElement::Forest],
+        ));
+        // hill
+        node_state_collections.push(NodeStateCollection::new(
+            String::from("hill"),
+            LandscapeElement::Hill,
+            vec![
+                LandscapeElement::Grass,
+                LandscapeElement::Hill,
+                LandscapeElement::Mountain,
+            ],
+        ));
+        // mountain
+        node_state_collections.push(NodeStateCollection::new(
+            String::from("mountain"),
+            LandscapeElement::Mountain,
+            vec![LandscapeElement::Hill, LandscapeElement::Mountain],
+        ));
+
+        let mut node_state_collection_ids: Vec<String> = Vec::new();
+        for node_state_collection in node_state_collections.iter() {
+            let node_state_collection_id: String = node_state_collection.id.clone();
+            node_state_collection_ids.push(node_state_collection_id);
+        }
+
+        let mut node_id_per_x_per_y: HashMap<u32, HashMap<u32, String>> = HashMap::new();
+        for height_index in 0..self.height {
+            let mut node_id_per_x: HashMap<u32, String> = HashMap::new();
+            for width_index in 0..self.width {
+                let node_id = format!("{}_{}", width_index, height_index);
+                node_id_per_x.insert(width_index, node_id);
+            }
+            node_id_per_x_per_y.insert(height_index, node_id_per_x);
+        }
+
+        debug!("connecting nodes");
+        let mut nodes: Vec<Node<LandscapeElement>> = Vec::new();
+        for from_height_index in 0..self.height {
+            for from_width_index in 0..self.width {
+                debug!("setup ({from_width_index}, {from_height_index})");
+                let from_node_id: String = node_id_per_x_per_y
+                    .get(&from_height_index)
+                    .unwrap()
+                    .get(&from_width_index)
+                    .unwrap()
+                    .clone();
+                let min_to_height_index: u32;
+                if from_height_index == 0 {
+                    min_to_height_index = 0;
+                } else {
+                    min_to_height_index = from_height_index - 1;
+                }
+                let max_to_height_index: u32;
+                if from_height_index == self.height - 1 {
+                    max_to_height_index = self.height - 1;
+                } else {
+                    max_to_height_index = from_height_index + 1;
+                }
+                let min_to_width_index: u32;
+                if from_width_index == 0 {
+                    min_to_width_index = 0;
+                } else {
+                    min_to_width_index = from_width_index - 1;
+                }
+                let max_to_width_index: u32;
+                if from_width_index == self.width - 1 {
+                    max_to_width_index = self.width - 1;
+                } else {
+                    max_to_width_index = from_width_index + 1;
+                }
+                let mut node_state_collection_ids_per_neighbor_node_id: HashMap<
+                    String,
+                    Vec<String>,
+                > = HashMap::new();
+
+                if true {
+                    // fully connected set of 8-to-1
+                    for to_height_index in min_to_height_index..=max_to_height_index {
+                        for to_width_index in min_to_width_index..=max_to_width_index {
+                            if !(from_height_index == to_height_index
+                                && from_width_index == to_width_index)
+                            {
+                                debug!("connecting ({from_width_index}, {from_height_index}) to ({to_width_index}, {to_height_index})");
+                                let to_node_id: String = node_id_per_x_per_y
+                                    .get(&to_height_index)
+                                    .unwrap()
+                                    .get(&to_width_index)
+                                    .unwrap()
+                                    .clone();
+                                node_state_collection_ids_per_neighbor_node_id
+                                    .insert(to_node_id, node_state_collection_ids.clone());
+                            }
+                        }
+                    }
+                } else {
+                    for to_height_index in min_to_height_index..=max_to_height_index {
+                        let to_width_index = from_width_index;
+                        if !(from_height_index == to_height_index) {
+                            debug!("connecting ({from_width_index}, {from_height_index}) to ({to_width_index}, {to_height_index})");
+                            let to_node_id: String = node_id_per_x_per_y
+                                .get(&to_height_index)
+                                .unwrap()
+                                .get(&to_width_index)
+                                .unwrap()
+                                .clone();
+                            node_state_collection_ids_per_neighbor_node_id
+                                .insert(to_node_id, node_state_collection_ids.clone());
+                        }
+                    }
+                    for to_width_index in min_to_width_index..=max_to_width_index {
+                        let to_height_index = from_height_index;
+                        if !(from_width_index == to_width_index) {
+                            debug!("connecting ({from_width_index}, {from_height_index}) to ({to_width_index}, {to_height_index})");
+                            let to_node_id: String = node_id_per_x_per_y
+                                .get(&to_height_index)
+                                .unwrap()
+                                .get(&to_width_index)
+                                .unwrap()
+                                .clone();
+                            node_state_collection_ids_per_neighbor_node_id
+                                .insert(to_node_id, node_state_collection_ids.clone());
+                        }
+                    }
+                }
+
+                let mut node_state_probability_per_node_state_id: HashMap<LandscapeElement, f32> =
+                    HashMap::new();
+                node_state_probability_per_node_state_id.insert(LandscapeElement::Water, 1.0);
+                node_state_probability_per_node_state_id.insert(LandscapeElement::Sand, 0.1);
+                node_state_probability_per_node_state_id.insert(LandscapeElement::Grass, 1.0);
+                node_state_probability_per_node_state_id.insert(LandscapeElement::Hill, 0.1);
+                node_state_probability_per_node_state_id.insert(LandscapeElement::Mountain, 1.0);
+                node_state_probability_per_node_state_id.insert(LandscapeElement::Tree, 0.1);
+                node_state_probability_per_node_state_id.insert(LandscapeElement::Forest, 1.0);
+
+                let node = Node::new(
+                    from_node_id,
+                    node_state_probability_per_node_state_id,
+                    node_state_collection_ids_per_neighbor_node_id,
+                );
+                nodes.push(node);
+            }
+        }
+
+        WaveFunction::new(nodes, node_state_collections)
+    }
+}
+
+fn run() {
+    let width: u32 = 50;
+    let height: u32 = 50;
+    let landscape = Landscape::new(width, height);
+
+    let wave_function = landscape.get_wave_function();
+
+    wave_function.validate().unwrap();
+
+    let mut random_instance = fastrand::Rng::new();
+    let random_seed = Some(random_instance.u64(..));
+    //let random_seed = Some(0);
+    //let random_seed = None;
+
+    let collapsed_wave_function = wave_function
+        .get_collapsable_wave_function::<AccommodatingCollapsableWaveFunction<LandscapeElement>>(
+            random_seed,
+        )
+        .collapse()
+        .unwrap();
+
+    let mut node_state_per_y_per_x: Vec<Vec<Option<LandscapeElement>>> = Vec::new();
+    for _ in 0..width {
+        let mut node_state_per_y: Vec<Option<LandscapeElement>> = Vec::new();
+        for _ in 0..height {
+            node_state_per_y.push(None);
+        }
+        node_state_per_y_per_x.push(node_state_per_y);
+    }
+
+    for (node, node_state) in collapsed_wave_function.node_state_per_node.into_iter() {
+        let node_split = node.split("_").collect::<Vec<&str>>();
+        let x = node_split[0].parse::<u32>().unwrap() as usize;
+        let y = node_split[1].parse::<u32>().unwrap() as usize;
+        node_state_per_y_per_x[x][y] = Some(node_state);
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("landscape", |b| b.iter(|| run()));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
Hey there, cool repo!

I'd like to contribute some things to your project and I thought it might make sense to add a small benchmark as a first PR to check whether the next changes will affect the performance.

You can run the benchmark (of the landscape example) via `cargo bench`. It will take some time and report the average run time of the main part of the code (I excluded the printing and we can probably improve the benchmark even more in the future)